### PR TITLE
Update Reddit search bang to use Google instead of DuckDuckGo

### DIFF
--- a/src/bang.ts
+++ b/src/bang.ts
@@ -23414,12 +23414,12 @@ export const bangs = [
     },
     {
         c: 'Research',
-        d: 'duckduckgo.com',
+        d: 'google.com',
         r: 415,
-        s: 'Reddit search (via DuckDuckGo)',
+        s: 'Reddit search (via Google)',
         sc: 'Reference (fun)',
-        t: 'ddgr',
-        u: 'https://duckduckgo.com/?q=site:reddit.com+{{{s}}}',
+        t: 'gr',
+        u: 'https://google.com/?q=site:reddit.com+{{{s}}}',
     },
     {
         c: 'Multimedia',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Reddit search experience has been updated to deliver search results via Google. Users will now benefit from an enhanced search process and refined query handling when looking for Reddit content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->