### PR TITLE
change ai remover placement in query

### DIFF
--- a/src/bang.ts
+++ b/src/bang.ts
@@ -41226,7 +41226,7 @@ export const bangs = [
         s: 'Google',
         sc: 'Google',
         t: 'g',
-        u: 'https://www.google.com/search?q={{{s}}}%20-ai',
+        u: 'https://www.google.com/search?q=-ai%20{{{s}}}',
     },
     {
         c: 'Online Services',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Google search shortcut so that "-ai" now appears before your search terms instead of after them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->