### PR TITLE
Remove -ai from google search

### DIFF
--- a/src/bang.ts
+++ b/src/bang.ts
@@ -41226,7 +41226,7 @@ export const bangs = [
         s: 'Google',
         sc: 'Google',
         t: 'g',
-        u: 'https://www.google.com/search?q=-ai%20{{{s}}}',
+        u: 'https://www.google.com/search?q={{{s}}}',
     },
     {
         c: 'Online Services',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Google search functionality to remove the "-ai" prefix from search queries, ensuring user input is used directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->